### PR TITLE
Arreglo de error en mostrarCarro

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ class App extends Component {
   }
 
   mostrarCarro = () => {
-    if(this.state.carro.length){
+    if(this.state.carro.length==0){
       return
     }
     this.setState({ esCarroVisible: !this.state.esCarroVisible })


### PR DESCRIPTION
Se arregla error en mostrarCarro dentro de src/app.js en el cual no se comparaba this.state.carro.length a 0, por lo que nunca llegaba al cambio de estado de esCarroVisible, impidiendo que el boton carro mostrara los productos disponibles